### PR TITLE
Create jekyll-gh-pages.yml

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -1,0 +1,38 @@
+name: Deploy Jekyll site to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main # Only build on pushes to the main branch
+  pull_request:
+    branches:
+      - main # Also build for pull requests targeting the main branch
+
+permissions:
+  contents: read # Only allow reading repository contents
+  pages: write   # Grant write access to GitHub Pages
+  id-token: write # Required for deployment to GitHub Pages
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.1 # Use the appropriate Ruby version for Jekyll
+
+      - name: Install dependencies
+        run: bundle install
+
+      - name: Build site with Jekyll
+        run: bundle exec jekyll build
+
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request adds a GitHub Actions workflow to automate the deployment of a Jekyll site to GitHub Pages. The workflow is triggered on pushes and pull requests targeting the `main` branch and includes steps for setting up Ruby, installing dependencies, building the site, and deploying it.

### Deployment automation:

* [`.github/workflows/jekyll-gh-pages.yml`](diffhunk://#diff-36a7fe6e9af1fc515ab07c70bee1dd529453c776db13abf7f5c6b2b3b34c4be3R1-R38): Added a new workflow to deploy the Jekyll site to GitHub Pages. The workflow includes triggers for `push` and `pull_request` events on the `main` branch, sets permissions for repository contents and GitHub Pages, and defines a `build` job with steps to check out the code, set up Ruby (version 3.1), install dependencies, build the site using Jekyll, and deploy it using the `actions/deploy-pages` action.